### PR TITLE
fixed typo in manual compiling method in README.md of asm TCP server

### DIFF
--- a/asm/README.md
+++ b/asm/README.md
@@ -3,5 +3,5 @@ I recommend using make to build - run `make main` or `make debug`\
 if you wish to compile manually, run
 ```
 nasm -f elf64 -F dwarf -o client.o client.asm
-gcc main.c client.o -o main -no-pie
+gcc client.c client.o -o main -no-pie
 ```


### PR DESCRIPTION
The pull request changes "main.c" to "client.c"